### PR TITLE
Create setup-file_folder_preset-for-english.sql

### DIFF
--- a/setup-file_folder_preset-for-english.sql
+++ b/setup-file_folder_preset-for-english.sql
@@ -1,0 +1,97 @@
+DELETE FROM file_folder_preset;
+
+INSERT INTO file_folder_preset (id,"module",logical_path) VALUES
+	 (175,'TRIAL_DOCUMENT','/8.0 Centralized Testing/8.1 Facility Documents/'),
+	 (176,'TRIAL_DOCUMENT','/8.0 Centralized Testing/8.2 Sample Documentation/'),
+	 (177,'TRIAL_DOCUMENT','/8.0 Centralized Testing/8.3 General (Testing)/'),
+	 (178,'TRIAL_DOCUMENT','/9.0 Third Parties/'),
+	 (179,'TRIAL_DOCUMENT','/9.0 Third Parties/9.1 Third Party Oversight/'),
+	 (180,'TRIAL_DOCUMENT','/9.0 Third Parties/9.2 Third Party Setup/'),
+	 (181,'TRIAL_DOCUMENT','/9.0 Third Parties/9.3 Third Party General/'),
+	 (182,'TRIAL_DOCUMENT','/10.0 Data Management/'),
+	 (186,'TRIAL_DOCUMENT','/10.0 Data Management/10.4 EDC Management/'),
+	 (183,'TRIAL_DOCUMENT','/10.0 Data Management/10.1 Data Mgmt Oversight/');
+INSERT INTO file_folder_preset (id,"module",logical_path) VALUES
+	 (184,'TRIAL_DOCUMENT','/10.0 Data Management/10.2 Data Capture/'),
+	 (185,'TRIAL_DOCUMENT','/10.0 Data Management/10.3 Database/'),
+	 (187,'TRIAL_DOCUMENT','/10.0 Data Management/10.5 General (Data Mgmt)/'),
+	 (190,'TRIAL_DOCUMENT','/11.0 Statistics/11.2 Randomization/'),
+	 (191,'TRIAL_DOCUMENT','/11.0 Statistics/11.3 Analysis/'),
+	 (192,'TRIAL_DOCUMENT','/11.0 Statistics/11.4 Report (Statistical)/'),
+	 (193,'TRIAL_DOCUMENT','/11.0 Statistics/11.5 General  (Statist)/'),
+	 (146,'TRIAL_DOCUMENT','/4.0 IRB_IEC and Other Approval/'),
+	 (147,'TRIAL_DOCUMENT','/4.0 IRB_IEC and Other Approval/4.1 IRB_IEC Trial Approv/'),
+	 (148,'TRIAL_DOCUMENT','/4.0 IRB_IEC and Other Approval/4.2 Other Committees/');
+INSERT INTO file_folder_preset (id,"module",logical_path) VALUES
+	 (150,'TRIAL_DOCUMENT','/4.0 IRB_IEC and Other Approval/4.4 General (IRB_IEC)/'),
+	 (149,'TRIAL_DOCUMENT','/4.0 IRB_IEC and Other Approval/4.3 Trial Status Rep/'),
+	 (136,'TRIAL_DOCUMENT','/2.0 Central Trial Documents/'),
+	 (137,'TRIAL_DOCUMENT','/2.0 Central Trial Documents/2.1 Prod + Trial Docs/'),
+	 (138,'TRIAL_DOCUMENT','/2.0 Central Trial Documents/2.2 Subject Documentation/'),
+	 (139,'TRIAL_DOCUMENT','/2.0 Central Trial Documents/2.3 Reports (Cent Trial)/'),
+	 (140,'TRIAL_DOCUMENT','/2.0 Central Trial Documents/2.4 General (Cent Trial)/'),
+	 (117,'INVENTORY_DOCUMENT','/1. Manuals/'),
+	 (118,'INVENTORY_DOCUMENT','/2. Reports and Certificates/'),
+	 (119,'INVENTORY_DOCUMENT','/3. Invoices/');
+INSERT INTO file_folder_preset (id,"module",logical_path) VALUES
+	 (120,'INVENTORY_DOCUMENT','/4. Miscellaneous/'),
+	 (210,'STAFF_DOCUMENT','/1. Curriculum Vitae/'),
+	 (211,'STAFF_DOCUMENT','/2. Certificates/'),
+	 (212,'STAFF_DOCUMENT','/3. Training Documents/'),
+	 (126,'COURSE_DOCUMENT','/1. Course Material/'),
+	 (127,'COURSE_DOCUMENT','/2. Participation Lists/'),
+	 (128,'COURSE_DOCUMENT','/3. Live Recordings/'),
+	 (129,'COURSE_DOCUMENT','/4. Miscellaneous/'),
+	 (200,'PROBAND_DOCUMENT','/1. Policy Documents/'),
+	 (201,'PROBAND_DOCUMENT','/2. Proof of Identity/');
+INSERT INTO file_folder_preset (id,"module",logical_path) VALUES
+	 (202,'PROBAND_DOCUMENT','/3. Findings/'),
+	 (203,'PROBAND_DOCUMENT','/4. Miscellaneous/'),
+	 (204,'PROBAND_DOCUMENT','/5. Receipts/'),
+	 (205,'MASS_MAIL_DOCUMENT','/1. Attachments/'),
+	 (206,'MASS_MAIL_DOCUMENT','/2. Images/'),
+	 (207,'MASS_MAIL_DOCUMENT','/3. Miscellaneous/'),
+	 (141,'TRIAL_DOCUMENT','/3.0 Regulatory/'),
+	 (142,'TRIAL_DOCUMENT','/3.0 Regulatory/3.1 Trial Approval/'),
+	 (143,'TRIAL_DOCUMENT','/3.0 Regulatory/3.2 Invest Med Product/'),
+	 (144,'TRIAL_DOCUMENT','/3.0 Regulatory/3.3 Trial Status Report/');
+INSERT INTO file_folder_preset (id,"module",logical_path) VALUES
+	 (145,'TRIAL_DOCUMENT','/3.0 Regulatory/3.4 General (Regulatory)/'),
+	 (164,'TRIAL_DOCUMENT','/6.0 IP and Trial Supplies/6.2 IP Release Process/'),
+	 (130,'TRIAL_DOCUMENT','/1.0 Trial Management/'),
+	 (131,'TRIAL_DOCUMENT','/1.0 Trial Management/1.1 Trial Oversight/'),
+	 (132,'TRIAL_DOCUMENT','/1.0 Trial Management/1.2 Trial Team/'),
+	 (133,'TRIAL_DOCUMENT','/1.0 Trial Management/1.3 Trial Committee/'),
+	 (134,'TRIAL_DOCUMENT','/1.0 Trial Management/1.4 Meetings (Trial Mgmt)/'),
+	 (135,'TRIAL_DOCUMENT','/1.0 Trial Management/1.5 General (Trial Mgmt)/'),
+	 (151,'TRIAL_DOCUMENT','/5.0 Site Management/'),
+	 (152,'TRIAL_DOCUMENT','/5.0 Site Management/5.1 Site Selection/');
+INSERT INTO file_folder_preset (id,"module",logical_path) VALUES
+	 (153,'TRIAL_DOCUMENT','/5.0 Site Management/5.2 Site Set-up/'),
+	 (154,'TRIAL_DOCUMENT','/5.0 Site Management/5.3 Site Initiation/'),
+	 (155,'TRIAL_DOCUMENT','/5.0 Site Management/5.4 Site Mgmt/'),
+	 (156,'TRIAL_DOCUMENT','/5.0 Site Management/5.5 General (Site Mgmt)/'),
+	 (157,'TRIAL_DOCUMENT','/6.0 IP and Trial Supplies/'),
+	 (158,'TRIAL_DOCUMENT','/6.0 IP and Trial Supplies/6.1 IP Documentation/'),
+	 (159,'TRIAL_DOCUMENT','/6.0 IP and Trial Supplies/6.2 IP Release Process/'),
+	 (160,'TRIAL_DOCUMENT','/6.0 IP and Trial Supplies/6.3 IP Allocation Docs/'),
+	 (161,'TRIAL_DOCUMENT','/6.0 IP and Trial Supplies/6.4 Storage (IP)/'),
+	 (162,'TRIAL_DOCUMENT','/6.0 IP and Trial Supplies/');
+INSERT INTO file_folder_preset (id,"module",logical_path) VALUES
+	 (163,'TRIAL_DOCUMENT','/6.0 IP and Trial Supplies/6.1 IP Documentation/'),
+	 (165,'TRIAL_DOCUMENT','/6.0 IP and Trial Supplies/6.3 IP Allocation Docs/'),
+	 (166,'TRIAL_DOCUMENT','/6.0 IP and Trial Supplies/6.4 Storage (IP)/'),
+	 (167,'TRIAL_DOCUMENT','/6.0 IP and Trial Supplies/6.5 Non-IP Documentation'),
+	 (168,'TRIAL_DOCUMENT','/6.0 IP and Trial Supplies/6.6 Interactive Resp Tech/'),
+	 (169,'TRIAL_DOCUMENT','/6.0 IP and Trial Supplies/6.7 General (IP Supply)/'),
+	 (170,'TRIAL_DOCUMENT','/7.0 Safety Reporting/'),
+	 (171,'TRIAL_DOCUMENT','/7.0 Safety Reporting/7.1 Safety Documentation/'),
+	 (172,'TRIAL_DOCUMENT','/7.0 Safety Reporting/7.2 Trial Status Rpting/'),
+	 (173,'TRIAL_DOCUMENT','/7.0 Safety Reporting/7.3 General (Safety Rpt)/');
+INSERT INTO file_folder_preset (id,"module",logical_path) VALUES
+	 (174,'TRIAL_DOCUMENT','/8.0 Centralized Testing/'),
+	 (188,'TRIAL_DOCUMENT','/11.0 Statistics/'),
+	 (189,'TRIAL_DOCUMENT','/11.0 Statistics/11.1 Statistics Oversight/'),
+	 (218,'STAFF_DOCUMENT','/5.0 Miscellaneous/'),
+	 (217,'STAFF_DOCUMENT','/4. Publications/'),
+	 (219,'STAFF_DOCUMENT','/5.0 Miscellaneous/5.1 Timecards/');


### PR DESCRIPTION
This is a SQL script I developed and tested to update the Document folder presets for English installations.

Source for the trial document structure is this Excel template from MasterControl: https://www.mastercontrol.com/uk/clinical/trial-master-file-structure/